### PR TITLE
Adds more description, deprecation notice and GitHub link

### DIFF
--- a/alerts/google_home_api_break.markdown
+++ b/alerts/google_home_api_break.markdown
@@ -1,10 +1,14 @@
 ---
-title: "Google Home bluetooth scanning no longer works"
+title: "Google Home device_tracker and alarm sensor no longer works"
 created: 2019-08-18 18:11:03
+updated: 2019-08-19 18:56:00
 integrations:
   - googlehome
+github_issue: https://github.com/home-assistant/home-assistant/issues/24815
 ---
 
-_This is demo content._
+For a couple of weeks/months this integration was broken when Google changed the port they serve this information on, and to require a token header in the request.
 
-Google has limited access from the API. It can no longer be used.
+# Deprecation
+
+The `googlehome` integration are now deprecated, and a [PR has been created](https://github.com/home-assistant/home-assistant/pull/26035) to remove it from Home Assistant.


### PR DESCRIPTION
This adds the following to the Google Home alert:

- More description
- A deprecation notice
- GitHub issue link

For a couple of weeks/months this integration was broken when Google changed the port they serve this information on, and to require a token header in the request.