### PR TITLE
Create apple_tv_tvos13.markdown

### DIFF
--- a/alerts/apple_tv_tvos13.markdown
+++ b/alerts/apple_tv_tvos13.markdown
@@ -1,0 +1,14 @@
+---
+title: "Apple TV integration incompatible with tvOS 13"
+created: 2019-09-07 18:20:03
+integrations:
+  - apple_tv
+github_issue: https://github.com/postlund/pyatv/issues/180
+homeassistant: >0.49
+---
+
+Updating your Apple TV to tvOS 13 will cause the Apple TV media player integration for Home Assistant to no longer work.
+
+The current version of the integration relies on the legacy DAAP-protocol which is being phased out in tvOS 13 in favor of the MediaRemoteTV protocol (MRP) going forward. This is a [known issue](https://github.com/postlund/pyatv/issues/180) which will require an update to the pyatv python library.
+
+If you wish to continue using the Apple TV media player integration in Home Assistant, it's recommended to hold off on installing tvOS 13 at this time. On your Apple TV device, navigate to Settings > System > Software Updates and turn off auto updates.


### PR DESCRIPTION
I think this is probably worthy of an alert? tvOS 13 software will be released to the public within the next several days and it completely breaks the Apple TV media player integration for HA. 

Doesn't seem like there's an imminent fix on the horizon so it would be nice to warn people of this and be able to point people to this alert if their setup breaks.