### PR TITLE
Update zwave_pi4_aeotec.markdown

### DIFF
--- a/alerts/zwave_pi4_aeotec.markdown
+++ b/alerts/zwave_pi4_aeotec.markdown
@@ -12,7 +12,7 @@ Z-Wave stick and the Raspberry Pi4 that causes the stick not to be detected.
 
 # Fix
 
-This can be worked around by connecting a USB 2.0 hub into the Pi, and the stick into the Pi.
+This can be worked around by connecting a USB 2.0 hub into the Pi, and the stick into the hub.
 
 Alternatively migrate to using another brand of Z-Wave stick. That would require removing all the devices from the current stick,
 and then including them with the new stick.


### PR DESCRIPTION
The fix/workaround described here didn't match the fix in link (https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=245031#p1504345).
Changing the second 'Pi' to 'hub' makes it correct.