### PR TITLE
Centralize Marked default options

### DIFF
--- a/src/layout/kb-detail.ts
+++ b/src/layout/kb-detail.ts
@@ -146,12 +146,7 @@ class KbDetail extends LitElement {
         content.innerHTML = filterXSS(
           marked(
             // Strip out the metadata
-            text.substr(text.indexOf("---", 1) + 4),
-            {
-              breaks: true,
-              gfm: true,
-              tables: true
-            }
+            text.substr(text.indexOf("---", 1) + 4)
           )
         );
         this._content = content;

--- a/src/util/load_markdown.ts
+++ b/src/util/load_markdown.ts
@@ -3,3 +3,8 @@ import { filterXSS as filterXSS_ } from "xss";
 
 export const marked = marked_;
 export const filterXSS = filterXSS_;
+
+marked.setOptions({
+  breaks: true,
+  gfm: true
+});


### PR DESCRIPTION
Pulled out the Marked render option into `load_markdown`, so whenever used, it has consistent output ono the site.

The `tables` option has been removed (tables are enabled always, not configurable).

This allows for rebasing and merging #41, which is now blocked due to a build failure.