### PR TITLE
Add access control header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,4 +1,5 @@
 /*
+  Access-Control-Allow-Origin: *
   Cache-Control: public, max-age: 0, s-maxage=900, must-revalidate
   Content-Security-Policy: form-action https:
   Feature-Policy: vibrate 'none'; geolocation 'none'; midi 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; payment 'none'


### PR DESCRIPTION
Sets the `Access-Control-Allow-Origin` header.

So we can make the alerts on our website work again...