### PR TITLE
Add alert about Automatic shutdown

### DIFF
--- a/alerts/automatic.markdown
+++ b/alerts/automatic.markdown
@@ -4,13 +4,14 @@ created: 2020-05-01 11:53:00
 integrations:
   - automatic
 github_issue: https://github.com/home-assistant/core/pull/35029
-homeassistant: ">0.0"
+homeassistant: ">0.110.0"
 ---
 
 The Automatic connected car platform is
 [shutting down operations on May 28, 2020](https://automatic.com/customerfaq) due to
 adverse impacts upon their business by COVID-19.
 
-Because this shutdown date coincides with the planned 0.110.0 release of Home Assistant,
-the `automatic` integration will be removed in that release. Users should anticipate
-removing any configuration related to `automatic` at that time
+Because this shutdown date will be one week after the 0.110.0 release of Home Assistant,
+that release will still allow use of the integration up to May 28. After that date,
+users will need to remove any configuration related to `automatic`. Full removal of the
+integration's code will occur in the 0.111.0 release.

--- a/alerts/automatic.markdown
+++ b/alerts/automatic.markdown
@@ -1,0 +1,16 @@
+---
+title: "Automatic platform shutting down on May 28, 2020"
+created: 2020-05-01 11:53:00
+integrations:
+  - automatic
+github_issue: https://github.com/home-assistant/core/pull/35029
+homeassistant: ">0.0"
+---
+
+The Automatic connected car platform is
+[shutting down operations on May 28, 2020](https://automatic.com/customerfaq) due to
+adverse impacts upon their business by COVID-19.
+
+Because this shutdown date coincides with the planned 0.110.0 release of Home Assistant,
+the `automatic` integration will be removed in that release. Users should anticipate
+removing any configuration related to `automatic` at that time


### PR DESCRIPTION
This PR adds an alert re: Automatic's planned shutdown on 5/28/2020.