### PR TITLE
Add alert for logi-circle

### DIFF
--- a/alerts/logi-circle.markdown
+++ b/alerts/logi-circle.markdown
@@ -7,4 +7,4 @@ github_issue: https://github.com/home-assistant/core/issues/36521
 homeassistant: ">0.60.0"
 ---
 
-Due to the ongoing situation with COVID-19, Logitech have temporarily stopped processing applications for new API accounts. Existing accounts should continue to work.
+Due to the ongoing situation with COVID-19, Logitech has temporarily stopped processing applications for new API accounts. Existing accounts should continue to work.

--- a/alerts/logi-circle.markdown
+++ b/alerts/logi-circle.markdown
@@ -1,0 +1,10 @@
+---
+title: "Logi Circle Temporarily Suspends API Applications"
+created: 2020-06-007 19:30:00
+integrations:
+  - logi_circle
+github_issue: https://github.com/home-assistant/core/issues/36521
+homeassistant: ">0.60.0"
+---
+
+Due to the ongoing situation with COVID-19, Logitech have temporarily stopped processing applications for new API accounts. Existing accounts should continue to work.

--- a/alerts/logi-circle.markdown
+++ b/alerts/logi-circle.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Logi Circle Temporarily Suspends API Applications"
-created: 2020-06-007 19:30:00
+created: 2020-06-07 19:30:00
 integrations:
   - logi_circle
 github_issue: https://github.com/home-assistant/core/issues/36521


### PR DESCRIPTION
Adds an alert for Logi Circle to cover the fact they've temporarily suspended new API accounts. See [here](https://docs.google.com/forms/d/184FUILJ10rVxotyOQR5DAiu6GcCbK31AZszUdzT1ybs/closedform).

I'll set up a cron job to check that page or is this something we want to handle with a workflow on here?