### PR TITLE
Add alert for Linky

### DIFF
--- a/alerts/linky.markdown
+++ b/alerts/linky.markdown
@@ -7,4 +7,4 @@ github_issue: https://github.com/home-assistant/core/issues/33634
 homeassistant: ">0.79.0"
 ---
 
-An automatic Enedis API changes from march 2020 make some users impossible to authenticate, a fix is in work in progress, see details on the GitHub issue.
+An automatic Enedis API changes from March 2020 makes it impossible for some users to authenticate. A fix is in work in progress, see details on the GitHub issue.

--- a/alerts/linky.markdown
+++ b/alerts/linky.markdown
@@ -1,0 +1,10 @@
+---
+title: "API changes from march 2020 make some users impossible to authenticate"
+created: 2020-07-13 10:40:00
+integrations:
+  - linky
+github_issue: https://github.com/home-assistant/core/issues/33634
+homeassistant: ">0.79.0"
+---
+
+An automatic Enedis API changes from march 2020 make some users impossible to authenticate, a fix is in work in progress, see details on the GitHub issue.

--- a/alerts/linky.markdown
+++ b/alerts/linky.markdown
@@ -1,5 +1,5 @@
 ---
-title: "API changes from march 2020 make some users impossible to authenticate"
+title: "Linky API changes from preventing authentication"
 created: 2020-07-13 10:40:00
 integrations:
   - linky


### PR DESCRIPTION
To stop people [creating issue](https://github.com/home-assistant/core/issues?q=is%3Aissue+label%3A%22integration%3A+linky%22) and discuss on it [on the forum](https://community.home-assistant.io/t/can-not-log-with-linky/71163) and Discord.

WIP fix in : https://github.com/hacf-fr/home-assistant-core/tree/linky/new-api