### PR TITLE
Alert for frontend issue with latest Apple betas

### DIFF
--- a/alerts/apple-betas-2020.markdown
+++ b/alerts/apple-betas-2020.markdown
@@ -4,6 +4,7 @@ created: 2020-08-22 11:00:00
 integrations:
   - frontend
   - ios
+  - mobile_app
 github_issue: https://github.com/home-assistant/frontend/issues/6654
 homeassistant: ">0.7"
 ---


### PR DESCRIPTION
Currently it is impossible to interact with the Home Assistant frontend controls in the latest betas from Apple (both iOS and macOS). The root cause seems to have been identified as a bug in the betas (confirmed by Google MWC) but it is affecting lots of users. We're seeing lots of reports of this. This report allows us to point to a single resource with the relevant links and template bug report, it also increases the chance of users seeing this before updating to the latest betas. It should be mentioned that this is a late regression in the iOS 14 beta cycle and there is a real chance this will make it to release.