### PR TITLE
Update Apple betas alert with details of fix in iOS14b6

### DIFF
--- a/alerts/apple-betas-2020.markdown
+++ b/alerts/apple-betas-2020.markdown
@@ -15,8 +15,6 @@ The frontend team has determined that the issue lies upstream of Home Assistant 
 
 Due to the way iOS works, this will affect all browsers (and our Companion App) on iOS devices. If you only need to log in to view your Home Assistant interface this can be done by using the return button on the keyboard to submit your login credentials. Push notifications and sensors for the Companion App are not affected.
 
-We would be grateful if affected users could raise the feedback with Apple through iOS or macOS's "Feedback" app or the [Apple feedback website](https://www.apple.com/feedback/). You may find the template report below useful:
+For those wishing to follow this we suggest you follow the active issues on our [frontend](https://github.com/home-assistant/frontend/issues/6654) and [iOS app](https://github.com/home-assistant/iOS/issues/925) repositories and also the [Webkit Bugzilla report](https://bugs.webkit.org/show_bug.cgi?id=215622).
 
-> In the latest betas, I see a crash when using a MWC control in web view and Safari (new in iOS 14.0b5, 18A5351d) Visit https://mwc-demos.glitch.me/ or https://demo.home-assistant.io/ and tap any button/toggle. Safari and a WKWebView will both have the rendering process crash. The same behaviour is seen in MacOS with the latest Safari Technology Preview 112 (Safari 14.0, WebKit 15610.1.25.5.1). Please see the related WebKit Bugzilla report at: https://bugs.webkit.org/show_bug.cgi?id=215732 for more details of the crash. 
-
-For those wishing to follow this we suggest you follow the active issues on our [frontend](https://github.com/home-assistant/frontend/issues/6654) and [iOS app](https://github.com/home-assistant/iOS/issues/925) repositories and also the [Webkit Bugzilla report](https://bugs.webkit.org/show_bug.cgi?id=215732).
+**Update 2020-08-26**: The underlying issue in WebKit has been resolved. This is included in iOS 14 beta 6 (18A5357e) which has now been released as a public beta. This alert will be closed when we confirm the next macOS Big Sur beta and Safari Technology Preview build also contains the fix.

--- a/alerts/apple-betas-2020.markdown
+++ b/alerts/apple-betas-2020.markdown
@@ -17,4 +17,4 @@ Due to the way iOS works, this will affect all browsers (and our Companion App) 
 
 For those wishing to follow this we suggest you follow the active issues on our [frontend](https://github.com/home-assistant/frontend/issues/6654) and [iOS app](https://github.com/home-assistant/iOS/issues/925) repositories and also the [Webkit Bugzilla report](https://bugs.webkit.org/show_bug.cgi?id=215622).
 
-**Update 2020-08-26**: The underlying issue in WebKit has been resolved. This is included in iOS 14 beta 6 (18A5357e) which has now been released as a public beta. This alert will be closed when we confirm the next macOS Big Sur beta and Safari Technology Preview build also contains the fix.
+**Update 2020-08-26**: The underlying issue in WebKit has been resolved. This fix is included in iOS 14 beta 6 (18A5357e) which has now been released as a public beta. This alert will be closed when we confirm the next macOS Big Sur beta and Safari Technology Preview build also contains the fix.


### PR DESCRIPTION
This issue is thankfully resolved in iOS (and friends) beta 6. We are waiting to confirm that the WebKit fix is also included in the next Safari betas (I don't see any reason why it shouldn't be). In the mean time update this alert to reference the fix and also to remove the request to send feedback (no point spamming Apple now). Also updates the WebKit issue to the original from a dupe.