### PR TITLE
Add alert for vorwerk users on the neato integration

### DIFF
--- a/alerts/neato-vorwerk-vendor.markdown
+++ b/alerts/neato-vorwerk-vendor.markdown
@@ -9,4 +9,8 @@ github_issue: https://github.com/home-assistant/core/issues/39378
 homeassistant: ">0.7"
 ---
 
-The Neato integration also allows for Vorwerk accounts to connect as they use the same API. Starting in August 2020 Vorwerk started to reach out to its user base about a new app called MyKobold. This app requires the users account to migrate to a new OAUTH model that enforces 2FA. The current integration does not support this so at this time we recommend users hold off on migrating their account to the new app. Vorwerk says the new app will take place in March 2021 so its safe to hold off for now. More details can be found in the linked github issue up top and from this [comment](https://github.com/home-assistant/core/issues/39165#issuecomment-680007713).
+The Neato integration also allows for Vorwerk accounts to connect as they use the same API.
+
+Starting in August 2020 Vorwerk started to reach out to its user base about a new app called MyKobold. This app requires the users account to migrate to a new OAUTH model that enforces 2FA. The current integration does not support this so at this time we recommend users hold off on migrating their account to the new app.
+
+Vorwerk says the new app will take place in March 2021 so it is safe to hold off for now. More details can be found in the linked GitHub issue up top and from this [comment](https://github.com/home-assistant/core/issues/39165#issuecomment-680007713).

--- a/alerts/neato-vorwerk-vendor.markdown
+++ b/alerts/neato-vorwerk-vendor.markdown
@@ -6,7 +6,7 @@ integrations:
 packages:
   - pybotvac
 github_issue: https://github.com/home-assistant/core/issues/39378
-homeassistant: All
+homeassistant: ">0.7"
 ---
 
 The Neato integration also allows for Vorwerk accounts to connect as they use the same API. Starting in August 2020 Vorwerk started to reach out to its user base about a new app called MyKobold. This app requires the users account to migrate to a new OAUTH model that enforces 2FA. The current integration does not support this so at this time we recommend users hold off on migrating their account to the new app. Vorwerk says the new app will take place in March 2021 so its safe to hold off for now. More details can be found in the linked github issue up top and from this [comment](https://github.com/home-assistant/core/issues/39165#issuecomment-680007713).

--- a/alerts/neato-vorwerk-vendor.markdown
+++ b/alerts/neato-vorwerk-vendor.markdown
@@ -1,0 +1,12 @@
+---
+title: Neato - Vorwerk Vendor 2FA Changes
+created: 2020-08-29T06:56:00+02:00
+integrations:
+  - neato
+packages:
+  - pybotvac
+github_issue: https://github.com/home-assistant/core/issues/39378
+homeassistant: All
+---
+
+The Neato integration also allows for Vorwerk accounts to connect as they use the same API. Starting in August 2020 Vorwerk started to reach out to its user base about a new app called MyKobold. This app requires the users account to migrate to a new OAUTH model that enforces 2FA. The current integration does not support this so at this time we recommend users hold off on migrating their account to the new app. Vorwerk says the new app will take place in March 2021 so its safe to hold off for now. More details can be found in the linked github issue up top and from this [comment](https://github.com/home-assistant/core/issues/39165#issuecomment-680007713).


### PR DESCRIPTION
We had a few users mention that Vorwerk is promoting a new app which migrates users account to a OAUTH model with 2FA.  The current integration does not support this and users have until March 2021 to migrate their account.  Setting up an alert letting them know not to do so until we fix things on the HA side otherwise they cannot use the integration.

https://github.com/home-assistant/core/issues/39378
https://github.com/home-assistant/core/issues/39165#issuecomment-680007713