### PR TITLE
Add alert for ecovacs due to 'sucks' abandonware

### DIFF
--- a/alerts/ecovacs_deebot.markdown
+++ b/alerts/ecovacs_deebot.markdown
@@ -1,0 +1,12 @@
+---
+title: "Ecovacs Deebot ping/control issues and abandonware api"
+created: 2020-10-22 13:00:00
+integrations:
+  - ecovacs
+github_issue: https://github.com/home-assistant/core/issues/38625
+homeassistant: ">0.49"
+---
+
+Ecovacs integration is supported by [sucks api](https://github.com/wpietri/sucks) which is now considered abandonware until someone else supports the project. There is an ongoing issue with connecting to, and being controlled by, Home Assistant. (See issue [#38625](https://github.com/home-assistant/core/issues/38625)).
+
+If connection is lost, re-connecting to your device through the Ecovacs mobile app may restore connection to Home Assistant.


### PR DESCRIPTION
See issue: https://github.com/home-assistant/core/issues/38625

Not sure if this warrants an alert or not, but seeing as:
1. Black friday is coming up
2. Ecovacs deebot was the winner of the "[2020 Robot Vacuum Wars](https://www.youtube.com/watch?v=bYjlDwY9wPo)"
3. Robo-vacuums are a common black friday deal

...I figured folks might want to know the state of HA integration before investing $600 in one.

@OverloadUT and/or @dgomes may want to chime in.