### PR TITLE
Add TP-Link alert

### DIFF
--- a/alerts/tplink.markdown
+++ b/alerts/tplink.markdown
@@ -6,4 +6,4 @@ integrations:
 homeassistant: ">0.89"
 ---
 
-In response to a security vulnerability TP-Link have removed their local management API for Kasa products in the latest firmware version which prevents Home Assistant communicating with the device. Please see [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) for details from TP-Link, release notes for firmware are not readily published by TP-Link. Please see [this discussion on our community forums](https://community.home-assistant.io/t/tp-link-hs110-smart-plug-disappears-after-latest-firmware-update/244229) for more details.
+TP-Link's latest firmware for Kasa Smart Home devices closes the port (9999) previously used for local control, rendering Home Assistant unable to communicate with these devices. Please see [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) for details from TP-Link, release notes for firmware are not readily published by TP-Link. Please see [this discussion on our community forums](https://community.home-assistant.io/t/tp-link-hs110-smart-plug-disappears-after-latest-firmware-update/244229) for more details.

--- a/alerts/tplink.markdown
+++ b/alerts/tplink.markdown
@@ -6,4 +6,4 @@ integrations:
 homeassistant: ">0.89"
 ---
 
-In response to a security vulnerability TP-Link have removed their local management API for Kasa products in the latest firmware version which prevents Home Assistant communicating with the device. Please see [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) for details from TP-Link, release notes for firmware are not readily published by TP-Link.
+In response to a security vulnerability TP-Link have removed their local management API for Kasa products in the latest firmware version which prevents Home Assistant communicating with the device. Please see [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) for details from TP-Link, release notes for firmware are not readily published by TP-Link. Please see [this discussion on our community forums](https://community.home-assistant.io/t/tp-link-hs110-smart-plug-disappears-after-latest-firmware-update/244229) for more details.

--- a/alerts/tplink.markdown
+++ b/alerts/tplink.markdown
@@ -1,0 +1,9 @@
+---
+title: "TP-Link Remove Local API"
+created: 2020-11-18 09:08:00
+integrations:
+  - tplink
+homeassistant: ">0.89"
+---
+
+In response to a security vulnerability TP-Link have removed their local management API for Kasa products in the latest firmware version which prevents Home Assistant communicating with the device. Please see [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) for details from TP-Link, release notes for firmware are not readily published by TP-Link.


### PR DESCRIPTION
As per [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) TP-Link have removed their local API effectively killing Kasa products in Home Assistant. I've spent a little time looking but it seems there is no easily accessible release notes on TP-Link's website.