### PR TITLE
Deprecating Ziggo Mediabox XL

### DIFF
--- a/alerts/ziggo_mediabox_xl.markdown
+++ b/alerts/ziggo_mediabox_xl.markdown
@@ -1,0 +1,13 @@
+---
+title: Ziggo Mediabox XL deprecation
+created: 2020-11-24T12:27:00+02:00
+integrations:
+  - ziggo_mediabox_xl
+packages:
+  - ziggo_mediabox_xl
+homeassistant: ">0.118.3"
+---
+
+Ziggo has been discouraging the use of the "thuisnetwerk" feature of the Mediabox XL, they even explain [how to undo this](https://www.ziggo.nl/klantenservice/wifi/horizon-uit-het-thuisnetwerk-verwijderen#/).
+
+It seems impossible to get the code running with new(er) mediaboxes and therefore the integration will be removed from Home Assistant in release 0.120.0.


### PR DESCRIPTION
Alerting users about the deprecation plans.
The documentation also warns people as per [this PR](https://github.com/home-assistant/home-assistant.io/pull/15743).