### PR TITLE
RSS feed in same order as site feed (by publish date)

### DIFF
--- a/build-scripts/gulp/alerts.js
+++ b/build-scripts/gulp/alerts.js
@@ -105,6 +105,14 @@ gulp.task("create-feeds", done => {
         )
       )
     };
+  }).sort( (a, b) => {
+    if (a.date_published > b.date_published){
+      return -1;
+    }
+    if (a.date_published < b.date_published){
+      return 1;
+    }
+    return 0;
   });
   fs.writeFileSync(`${buildDir}/feed.xml`, jsonfeedToAtom(jsonfeed));
   done();


### PR DESCRIPTION
I noticed the RSS feed for the alerts site is not in the same order as the webpage. The events in the feed appear to be ordered alphabetically by entry ID rather then by publish date. This makes it difficult to use the RSS feed since external readers or feed watchers like the [feedreader](https://www.home-assistant.io/integrations/feedreader/) integration in Home Assistant generally expect RSS feeds to be in date order.

This PR fixes this by changing the script to sort the feed by `date_published` after it is created from the list of alerts in the folder.

Note that this is potentially a breaking change as it will change the order of the feed for existing watchers. I personally feel it is the right approach to make it easier to use going forward. Also existing automation for notifying people of new alerts will likely continue to work since currently it would have to dig through the entries to find the latest any time the feed updates. That still would work fine after this PR it just would no longer be necessary.