### PR TITLE
Add alert about Nello cloud API outage

### DIFF
--- a/alerts/nello.markdown
+++ b/alerts/nello.markdown
@@ -1,0 +1,11 @@
+---
+title: "Nello API outage"
+created: 2020-07-13 12:08:33
+github_issue: https://github.com/LFE89/nello_one_without_cloud/issues/1
+integrations:
+  - nello
+---
+
+After the MQTT server of Nello has been unreachable for several weeks now, the [homepage](https://www.nello.io/) and the [API](https://public-api.nello.io/v1/) are also unreachable since noon today (12:08:33 CET).
+
+SCLAK, which has operated Nello's infrastructure until now, filed for bankruptcy in October 2020 and has not responded to requests for weeks.

--- a/alerts/nello.markdown
+++ b/alerts/nello.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Nello API outage"
-created: 2020-07-13 12:08:33
+created: 2021-07-13 12:08:33
 github_issue: https://github.com/LFE89/nello_one_without_cloud/issues/1
 integrations:
   - nello


### PR DESCRIPTION
According to https://analytics.home-assistant.io/#integrations, the Nello integration doesn't have a particularly large user base, so I could understand if that's too unimportant here.