### PR TITLE
Add alert for Ecovacs integration due to unmaintained dependency.

### DIFF
--- a/alerts/ecovacs.markdown
+++ b/alerts/ecovacs.markdown
@@ -12,6 +12,6 @@ The Ecovacs integration relies on a dependency that is no longer supported by th
 
 ## Workaround
 
-There are replacement custom integrations that can be used as a replacement. The configuration parameters remain the same, but the dependencies are supported under a new project.
+There is a custom integration that can be uinstalled as a drop-in replacement. The configuration parameters remain the same, but the dependencies are supported under a new project.
 
 See custom integration here: https://github.com/Ligio/hacc-ozmo

--- a/alerts/ecovacs.markdown
+++ b/alerts/ecovacs.markdown
@@ -1,0 +1,17 @@
+---
+title: "Ecovacs integration dependency no longer maintained 2020.3.4-12"
+created: 2021-10-07 14:00:00
+updated: 2021-10-07 14:00:00
+integrations:
+  - ecovacs
+github_issue: https://github.com/home-assistant/core/issues/57282
+homeassistant: ">0.77"
+---
+
+The Ecovacs integration relies on a dependency that is no longer supported by the code maintainer.
+
+## Workaround
+
+There are replacement custom integrations that can be used as a replacement. The configuration parameters remain the same, but the dependencies are supported under a new project.
+
+See custom integration here: https://github.com/Ligio/hacc-ozmo

--- a/alerts/ecovacs.markdown
+++ b/alerts/ecovacs.markdown
@@ -8,7 +8,7 @@ github_issue: https://github.com/home-assistant/core/issues/57282
 homeassistant: ">0.77"
 ---
 
-The Ecovacs integration relies on a dependency that is no longer supported by the code maintainer.
+The Ecovacs integration relies on a dependency (sucks: https://github.com/wpietri/sucks) that is no longer supported by the code maintainer.
 
 ## Workaround
 


### PR DESCRIPTION
This PR adds an alert to the Ecovacs integration. This integration relies on the "sucks" library that is no longer maintained (https://github.com/wpietri/sucks).

I have found a replacement custom component that does work well, and I do think the integration should migrate over to it: https://github.com/Ligio/hacc-ozmo