### PR TITLE
Add alert for neato on unsupported botvacs

### DIFF
--- a/alerts/neato.markdown
+++ b/alerts/neato.markdown
@@ -1,9 +1,9 @@
 ---
 title: "New Neato Botvacs Do Not Support Existing API"
-created: 2021-08-11 13:27:00
+created: 2021-12-20 13:27:00
 integrations:
   - neato
-homeassistant: "any"
+homeassistant: "*"
 ---
 
 New Neato Botvacs no longer use the existing API that the current integration supports. So far the Neato D8 is using a new app and has no known API.

--- a/alerts/neato.markdown
+++ b/alerts/neato.markdown
@@ -1,0 +1,11 @@
+---
+title: "New Neato Botvacs Do Not Support Existing API"
+created: 2021-08-11 13:27:00
+integrations:
+  - neato
+homeassistant: "any"
+---
+
+New Neato Botvacs no longer use the existing API that the current integration supports. So far the Neato D8 is using a new app and has no known API.
+
+Neato says they have plans to add an API but as of now any botvac that requires the new "My Neato" app will not work with the existing integration.

--- a/alerts/neato.markdown
+++ b/alerts/neato.markdown
@@ -3,7 +3,7 @@ title: "New Neato Botvacs Do Not Support Existing API"
 created: 2021-12-20 13:27:00
 integrations:
   - neato
-homeassistant: "*"
+homeassistant: ">0.30"
 ---
 
 New Neato Botvacs no longer use the existing API that the current integration supports. So far the Neato D8 is using a new app and has no known API.


### PR DESCRIPTION
It has come to our realization that new Neato devices no longer use the existing API so we need to notify users of such.

Fixes https://github.com/home-assistant/home-assistant.io/issues/20779