### PR TITLE
Clarify alert

### DIFF
--- a/alerts/tplink.markdown
+++ b/alerts/tplink.markdown
@@ -8,7 +8,7 @@ homeassistant: ">0.89"
 
 ## Summary
 
-TP-Link's latest firmware for Kasa Smart Home devices closes the port (9999) previously used for local control, rendering Home Assistant unable to communicate with these devices. Please see [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) for details from TP-Link, release notes for firmware are not readily published by TP-Link. Please see [this discussion on our community forums](https://community.home-assistant.io/t/tp-link-hs110-smart-plug-disappears-after-latest-firmware-update/244229) for more details.
+TP-Link's latest firmware for certain Kasa Smart Home devices (e.g. HS100, HS110) closes the port (9999) previously used for local control, rendering Home Assistant unable to communicate with these devices. Please see [this tweet](https://twitter.com/TPLINKUK/status/1328687659133399043) for details from TP-Link, release notes for firmware are not readily published by TP-Link. Please see [this discussion on our community forums](https://community.home-assistant.io/t/tp-link-hs110-smart-plug-disappears-after-latest-firmware-update/244229) for more details.
 
 ## Update 2020/11/23
 


### PR DESCRIPTION
This alert creates confusion amongst potential users of Kasa devices. Clarify that the TP-Link alert only applies to certain UK-based plugs.