### PR TITLE
Twitch API Shutdown Alert

### DIFF
--- a/alerts/twitch.markdown
+++ b/alerts/twitch.markdown
@@ -1,0 +1,12 @@
+---
+title: "Twitch API v5 shutting down"
+created: 2022-02-11 12:00:00
+updated: 2022-02-1112:00:00
+integrations:
+  - twitch
+github_issue: https://github.com/home-assistant/core/issues/54385
+homeassistant: ">2021.2"
+---
+
+Twitch is shutting down their v5 api which the current Twitch integration is based on. The complete shutdown will occur February 28, 2022. No new Twitch developer applications can use the old api and existing users will be blocked from using it after the shutdown date.
+

--- a/alerts/twitch.markdown
+++ b/alerts/twitch.markdown
@@ -1,7 +1,7 @@
 ---
 title: "Twitch API v5 shutting down"
 created: 2022-02-11 12:00:00
-updated: 2022-02-1112:00:00
+updated: 2022-02-11 12:00:00
 integrations:
   - twitch
 github_issue: https://github.com/home-assistant/core/issues/54385

--- a/alerts/twitch.markdown
+++ b/alerts/twitch.markdown
@@ -5,7 +5,7 @@ updated: 2022-02-11 12:00:00
 integrations:
   - twitch
 github_issue: https://github.com/home-assistant/core/issues/54385
-homeassistant: ">2021.2"
+homeassistant: ">0.10"
 ---
 
 Twitch is shutting down their v5 api which the current Twitch integration is based on. The complete shutdown will occur February 28, 2022. No new Twitch developer applications can use the old api and existing users will be blocked from using it after the shutdown date.


### PR DESCRIPTION
Twitch is completely shutting down their v5 API on February 28, 2022. This is the API the current integration is based on. See: https://github.com/home-assistant/core/issues/54385

There is a workaround of a custom integration, but I didn't want to add it to the alert since it's not a HA supported item.