### PR TITLE
Add alert for Logi Circle

### DIFF
--- a/alerts/logi_circle.markdown
+++ b/alerts/logi_circle.markdown
@@ -7,6 +7,6 @@ github_issue: https://github.com/home-assistant/core/issues/71945
 homeassistant: ">0.92.0"
 ---
 
-Logitech are no longer accepting applications for access to the Logi Circle API.
+Logitech is no longer accepting applications for access to the Logi Circle API.
 
 For existing users that have already obtained an API key, the Logi Circle API will continue to function. However, you may not be able to update your redirect URI.

--- a/alerts/logi_circle.markdown
+++ b/alerts/logi_circle.markdown
@@ -1,0 +1,12 @@
+---
+title: "Logitech no longer accepting API applications"
+created: 2022-05-16 12:00:00
+integrations:
+  - logi_circle
+github_issue: https://github.com/home-assistant/core/issues/71945
+homeassistant: ">0.92.0"
+---
+
+Logitech are no longer accepting applications for access to the Logi Circle API.
+
+For existing users that have already obtained an API key, the Logi Circle API will continue to function. However, you may not be able to update your redirect URI.


### PR DESCRIPTION
Logitech have stopped accepting API applications for the Logi Circle API. This appears to be permanent.