### PR TITLE
Rename min/max to introduced_in/resolved_in

### DIFF
--- a/build-scripts/gulp/alerts.js
+++ b/build-scripts/gulp/alerts.js
@@ -71,6 +71,20 @@ function gatherAlertsMetadata() {
 
 gulp.task("gather-alerts", (done) => {
   const alerts = gatherAlertsMetadata();
+
+  // Backwards compat for change made in July 2022
+  for (const alert of alerts) {
+    if (!("homeassistant" in alert)) {
+      continue;
+    }
+    if ("affected_from_version" in alert.homeassistant) {
+      alert.homeassistant.min = alert.homeassistant.affected_from_version;
+    }
+    if ("resolved_in_version" in alert.homeassistant) {
+      alert.homeassistant.max = alert.homeassistant.resolved_in_version;
+    }
+  }
+
   fs.writeFileSync(`${buildDir}/alerts.json`, JSON.stringify(alerts));
   done();
 });

--- a/build-scripts/gulp/alerts.js
+++ b/build-scripts/gulp/alerts.js
@@ -24,9 +24,9 @@ class VersionedItem {
       part = part.replace(/,/, "");
 
       if (part[0] === ">") {
-        this.introduced_in = part.substr(1);
+        this.min_version = part.substr(1);
       } else if (part[0] === "<") {
-        this.resolved_in = part.substr(1);
+        this.resolved_in_version = part.substr(1);
       } else {
         throw new Error(`Error parsing ${this.package}: ${part}`);
       }

--- a/build-scripts/gulp/alerts.js
+++ b/build-scripts/gulp/alerts.js
@@ -24,9 +24,9 @@ class VersionedItem {
       part = part.replace(/,/, "");
 
       if (part[0] === ">") {
-        this.min = part.substr(1);
+        this.introduced_in = part.substr(1);
       } else if (part[0] === "<") {
-        this.max = part.substr(1);
+        this.resolved_in = part.substr(1);
       } else {
         throw new Error(`Error parsing ${this.package}: ${part}`);
       }

--- a/build-scripts/gulp/alerts.js
+++ b/build-scripts/gulp/alerts.js
@@ -24,7 +24,7 @@ class VersionedItem {
       part = part.replace(/,/, "");
 
       if (part[0] === ">") {
-        this.min_version = part.substr(1);
+        this.affected_from_version = part.substr(1);
       } else if (part[0] === "<") {
         this.resolved_in_version = part.substr(1);
       } else {

--- a/src/components/kb-display-version.ts
+++ b/src/components/kb-display-version.ts
@@ -3,7 +3,7 @@ import {
   LitElement,
   property,
   TemplateResult,
-  customElement
+  customElement,
 } from "lit-element";
 import { VersionSpec } from "../data/alert";
 
@@ -18,17 +18,17 @@ class KbDisplayVersion extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const { package: pkg, min_version, resolved_in_version } = this.version;
+    const {
+      package: pkg,
+      affected_from_version,
+      resolved_in_version,
+    } = this.version;
 
     return html`
-      ${this.href
-        ? html`
-            <a href=${this.href}>${pkg}</a>
-          `
-        : pkg}
-      ${min_version && resolved_in_version
-        ? `(${min_version}…<${resolved_in_version})`
-        : min_version
+      ${this.href ? html` <a href=${this.href}>${pkg}</a> ` : pkg}
+      ${affected_from_version && resolved_in_version
+        ? `(${affected_from_version}…<${resolved_in_version})`
+        : affected_from_version
         ? `(>=${resolved_in_version})`
         : resolved_in_version
         ? `(<${resolved_in_version})`

--- a/src/components/kb-display-version.ts
+++ b/src/components/kb-display-version.ts
@@ -18,7 +18,7 @@ class KbDisplayVersion extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const { package: pkg, introduced_in, resolved_in } = this.version;
+    const { package: pkg, min_version, resolved_in_version } = this.version;
 
     return html`
       ${this.href
@@ -26,12 +26,12 @@ class KbDisplayVersion extends LitElement {
             <a href=${this.href}>${pkg}</a>
           `
         : pkg}
-      ${introduced_in && resolved_in
-        ? `(${introduced_in}…<${resolved_in})`
-        : introduced_in
-        ? `(>=${resolved_in})`
-        : resolved_in
-        ? `(<${resolved_in})`
+      ${min_version && resolved_in_version
+        ? `(${min_version}…<${resolved_in_version})`
+        : min_version
+        ? `(>=${resolved_in_version})`
+        : resolved_in_version
+        ? `(<${resolved_in_version})`
         : ""}
     `;
   }

--- a/src/components/kb-display-version.ts
+++ b/src/components/kb-display-version.ts
@@ -18,7 +18,7 @@ class KbDisplayVersion extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const { package: pkg, min, max } = this.version;
+    const { package: pkg, introduced_in, resolved_in } = this.version;
 
     return html`
       ${this.href
@@ -26,12 +26,12 @@ class KbDisplayVersion extends LitElement {
             <a href=${this.href}>${pkg}</a>
           `
         : pkg}
-      ${min && max
-        ? `(${min}…${max})`
-        : min
-        ? `(>=${min})`
-        : max
-        ? `(<${max})`
+      ${introduced_in && resolved_in
+        ? `(${introduced_in}…<${resolved_in})`
+        : introduced_in
+        ? `(>=${resolved_in})`
+        : resolved_in
+        ? `(<${resolved_in})`
         : ""}
     `;
   }

--- a/src/components/kb-hass-version.ts
+++ b/src/components/kb-hass-version.ts
@@ -17,15 +17,15 @@ class KbHassVersion extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const { introduced_in, resolved_in } = this.version;
+    const { min_version, resolved_in_version } = this.version;
 
     return html`
-      ${introduced_in && resolved_in
-        ? `${introduced_in}…<${resolved_in}`
-        : introduced_in
-        ? `>=${introduced_in}`
-        : resolved_in
-        ? `<${resolved_in}`
+      ${min_version && resolved_in_version
+        ? `${min_version}…<${resolved_in_version}`
+        : min_version
+        ? `>=${min_version}`
+        : resolved_in_version
+        ? `<${resolved_in_version}`
         : "all versions"}
     `;
   }

--- a/src/components/kb-hass-version.ts
+++ b/src/components/kb-hass-version.ts
@@ -17,15 +17,15 @@ class KbHassVersion extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const { min, max } = this.version;
+    const { introduced_in, resolved_in } = this.version;
 
     return html`
-      ${min && max
-        ? `${min}…${max}`
-        : min
-        ? `>=${min}`
-        : max
-        ? `<${max}`
+      ${introduced_in && resolved_in
+        ? `${introduced_in}…<${resolved_in}`
+        : introduced_in
+        ? `>=${introduced_in}`
+        : resolved_in
+        ? `<${resolved_in}`
         : "all versions"}
     `;
   }

--- a/src/components/kb-hass-version.ts
+++ b/src/components/kb-hass-version.ts
@@ -3,7 +3,7 @@ import {
   LitElement,
   property,
   TemplateResult,
-  customElement
+  customElement,
 } from "lit-element";
 import { VersionSpec } from "../data/alert";
 
@@ -17,13 +17,13 @@ class KbHassVersion extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const { min_version, resolved_in_version } = this.version;
+    const { affected_from_version, resolved_in_version } = this.version;
 
     return html`
-      ${min_version && resolved_in_version
-        ? `${min_version}…<${resolved_in_version}`
-        : min_version
-        ? `>=${min_version}`
+      ${affected_from_version && resolved_in_version
+        ? `${affected_from_version}…<${resolved_in_version}`
+        : affected_from_version
+        ? `>=${affected_from_version}`
         : resolved_in_version
         ? `<${resolved_in_version}`
         : "all versions"}

--- a/src/data/alert.ts
+++ b/src/data/alert.ts
@@ -1,7 +1,7 @@
 export interface VersionSpec {
   package: string;
-  min?: string;
-  max?: string;
+  introduced_in?: string;
+  resolved_in?: string;
 }
 export interface Alert {
   title: string;

--- a/src/data/alert.ts
+++ b/src/data/alert.ts
@@ -1,6 +1,6 @@
 export interface VersionSpec {
   package: string;
-  min_version?: string;
+  affected_from_version?: string;
   resolved_in_version?: string;
 }
 export interface Alert {
@@ -16,4 +16,4 @@ export interface Alert {
 
 export const fetchAlerts = (): Promise<Alert[]> =>
   // Add domain because used inside custom element which can be used anywhere
-  fetch("https://alerts.home-assistant.io/alerts.json").then(r => r.json());
+  fetch("https://alerts.home-assistant.io/alerts.json").then((r) => r.json());

--- a/src/data/alert.ts
+++ b/src/data/alert.ts
@@ -1,7 +1,7 @@
 export interface VersionSpec {
   package: string;
-  introduced_in?: string;
-  resolved_in?: string;
+  min_version?: string;
+  resolved_in_version?: string;
 }
 export interface Alert {
   title: string;


### PR DESCRIPTION
~~Set to draft because this change will break clients relying on the min/max naming~~

Rename min/max to affected_from_version/resolved_in_version. Old properties are maintained for backwards compatibility.