### PR TITLE
Remove SoChain integration alert

### DIFF
--- a/alerts/sochain.markdown
+++ b/alerts/sochain.markdown
@@ -1,9 +1,0 @@
----
-title: "The SoChain integration is disabled due to a dependency conflict"
-created: 2022-02-01 0:00:00
-integrations:
-  - sochain
----
-
-The SoChain integration is disabled due to a dependency conflict, and is currently unusable.
-More information is available here: https://github.com/home-assistant/core/issues/68854


### PR DESCRIPTION
It no longer applies in Home Assistant 2022.8.0.

Marked as a draft until 2022.8 is shipped.