### PR TITLE
Add supervisor key to alerts.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ List of impacted integrations combined with version ranges.
 
 List of impacted Python packages combined with version ranges.
 
+### Supervisor (optional)
+
+Supervisor versions impacted.
+
 ## Deployment
 
 Deployments are handled by [Netlify](https://www.netlify.com/), on each merge to master a new site will be built.

--- a/build-scripts/gulp/alerts.js
+++ b/build-scripts/gulp/alerts.js
@@ -51,6 +51,12 @@ function gatherAlertsMetadata() {
         `homeassistant ${metadata.homeassistant || ""}`
       );
 
+      if (metadata.supervisor) {
+        metadata.supervisor = new VersionedItem(
+          `supervisor ${metadata.supervisor}`
+        );
+      }
+
       for (const versionKey of ["packages", "integrations"]) {
         if (versionKey in metadata) {
           metadata[versionKey] = metadata[versionKey].map(


### PR DESCRIPTION
Adds a new `"supervisor"` key to the generated alerts.json file.

example:
```json
"supervisor":{"package":"supervisor","affected_from_version":"2022.11.0","resolved_in_version":"2022.11.1"}
```

Core PR: https://github.com/home-assistant/core/pull/82862