### PR TITLE
Add Yale Home migration alert to august

### DIFF
--- a/alerts/august.md
+++ b/alerts/august.md
@@ -1,0 +1,10 @@
+---
+title: "Yale Home app migration"
+created: 2023-05-16 20:00:00
+integrations:
+  - august
+---
+
+## Summary
+
+Yale is migrating some Yale Access users outside North America to a new Yale Home app. If you use the August integration or Yale Access Cloud integration, migrating your account to Yale Home will prevent the integration from accessing your account.


### PR DESCRIPTION
The August integration is about to break for anyone outside of North America who migrates their account to Yale Home (which is now being offered as of a few minutes/hours ago)