### PR TITLE
Create faa_delays alert

### DIFF
--- a/alerts/faa_delays
+++ b/alerts/faa_delays
@@ -1,0 +1,12 @@
+---
+title: "FAA Delays is temporarily not providing data"
+created: 2023-07-31 00:00:00
+integrations:
+  - faa_delays
+homeassistant: ">2021.3"
+---
+
+## Summary
+
+The FAA Delays API has been updated and the Home Assistant integration is not currently updating. Users with already set up integrations will see that it shows Unavailable. Users attempting to set up a new integration will receive an error. Work to remedy the problem is underway.
+


### PR DESCRIPTION
This is an alert to provide context to anyone experiencing errors with the FAA delays integration as detailed in https://github.com/home-assistant/core/issues/90674.