### PR TITLE
Add Unifi Protect 3.x backward incompatible alert

### DIFF
--- a/alerts/unifiprotect.md
+++ b/alerts/unifiprotect.md
@@ -1,0 +1,10 @@
+---
+title: "Unifi Protect 3.x backwards incompatible changes"
+created: 2024-03-21 0:00:00
+integrations:
+  - unifiprotect
+---
+
+## Summary
+
+The latest firmware for Unifi Protect devices contains backward incompatible changes that are incompatible with older versions of Home Assistant. To avoid disruption, upgrade to Home Assistant 2024.3.2 or later before upgrading Unifi Protect to 3.x.

--- a/alerts/unifiprotect.md
+++ b/alerts/unifiprotect.md
@@ -3,6 +3,7 @@ title: "Unifi Protect 3.x backward incompatible changes"
 created: 2024-03-21 0:00:00
 integrations:
   - unifiprotect
+homeassistant: "<2024.3.2"
 ---
 
 ## Summary

--- a/alerts/unifiprotect.md
+++ b/alerts/unifiprotect.md
@@ -1,5 +1,5 @@
 ---
-title: "Unifi Protect 3.x backwards incompatible changes"
+title: "Unifi Protect 3.x backward incompatible changes"
 created: 2024-03-21 0:00:00
 integrations:
   - unifiprotect


### PR DESCRIPTION
Users are upgrading to Unifi Protect 3.x and finding it has backwards incompatible changes which break the integration.

> The latest firmware for Unifi Protect devices contains backward incompatible changes that are incompatible with older versions of Home Assistant. To avoid disruption, upgrade to Home Assistant 2024.3.2 or later before upgrading Unifi Protect to 3.x.
