### PR TITLE
Improve UniFi Protect alert wording

### DIFF
--- a/alerts/unifiprotect.md
+++ b/alerts/unifiprotect.md
@@ -1,5 +1,5 @@
 ---
-title: "Unifi Protect 3.x backward incompatible changes"
+title: "UniFi Protect 3.x backward incompatible changes"
 created: 2024-03-21 0:00:00
 integrations:
   - unifiprotect
@@ -8,4 +8,4 @@ homeassistant: "<2024.3.2"
 
 ## Summary
 
-The latest firmware for Unifi Protect devices contains backward incompatible changes that are incompatible with older versions of Home Assistant. To avoid disruption, upgrade to Home Assistant 2024.3.2 or later before upgrading Unifi Protect to 3.x.
+The latest firmware for UniFi Protect devices contains changes that are incompatible with older versions of Home Assistant. To avoid disruption, upgrade to Home Assistant 2024.3.2 or later before upgrading UniFi Protect to 3.x.


### PR DESCRIPTION
This PR improves the wording of the UniFi Protect alert and also correctly capitalizes "UniFi" (instead of "Unifi").

- Follow-up to: https://github.com/home-assistant/alerts.home-assistant.io/pull/629

On the Ubiquiti Discord, it was mentioned that "backward incompatible changes that are incompatible" is somewhat redundant, hence the first part is removed.