### PR TITLE
Add UniFi OS 4.x backward incompatible alert

### DIFF
--- a/alerts/unifiprotect.md
+++ b/alerts/unifiprotect.md
@@ -1,5 +1,5 @@
 ---
-title: "UniFi OS backward incompatible changes"
+title: "UniFi OS 4.x backward incompatible changes"
 created: 2024-05-29 0:00:00
 integrations:
   - unifiprotect

--- a/alerts/unifiprotect.md
+++ b/alerts/unifiprotect.md
@@ -7,4 +7,4 @@ integrations:
 
 ## Summary
 
-UniFi OS 4.x contains changes that are incompatible with current versions of Home Assistant. To avoid disruption, do not upgrade to UniFi OS 4.x.
+UniFi OS 4.x contains changes that are incompatible with the UniFi Protect integration in current versions of Home Assistant. To avoid disruption, do not upgrade to UniFi OS 4.x.

--- a/alerts/unifiprotect.md
+++ b/alerts/unifiprotect.md
@@ -1,11 +1,10 @@
 ---
-title: "UniFi Protect 3.x backward incompatible changes"
-created: 2024-03-21 0:00:00
+title: "UniFi OS backward incompatible changes"
+created: 2024-05-29 0:00:00
 integrations:
   - unifiprotect
-homeassistant: "<2024.3.2"
 ---
 
 ## Summary
 
-The latest firmware for UniFi Protect devices contains changes that are incompatible with older versions of Home Assistant. To avoid disruption, upgrade to Home Assistant 2024.3.2 or later before upgrading UniFi Protect to 3.x.
+UniFi OS 4.x contains changes that are incompatible with current versions of Home Assistant. To avoid disruption, do not upgrade to UniFi OS 4.x.


### PR DESCRIPTION
### Proposed change

This removes the old alert about UniFi Protect 3.x being incompatible, as it's compatible with HA since multiple months now.
Instead, the alert is replaced with one mentioning that UniFi OS 4.x is still incompatible with the UniFi Protect integration.


### Additional information

Whilst I dislike the advice of not upgrading to UniFi OS 4.x, this is the only workaround that doesn't involve editing the library for now. I really hope we can fix the integration soon. For now, an alert is the best thing to do IMO.


The UniFi OS 4.x issue is tracked here:
- https://github.com/home-assistant/core/issues/117100

UniFi OS 4.x is not to be mixed up with UniFi Protect 4.x.
Protect 4.x also has some issues with the HA integration, but they aren't major issues compared to the OS 4.x one, see:
- https://github.com/home-assistant/core/issues/117274

If wanted, I can also add a note about Protect 4.x, but I don't think it's really necessary.

### Note

UniFi OS 4.x is still in EA for now. Even though the documentation for the Protect integration states that EA is not supported, a lot of users are upgrading and notice that the integration breaks completely (no workaround).
To warn those users, this alert should be added. It's likely that the release goes to RC/GA soon, too.

Due to the unfortunate circumstances regarding the Protect integration, it's still not updated to support any of the 4.x updates to UniFi OS/Protect.