### PR TITLE
Tesla Fleet built in credential is being removed

### DIFF
--- a/alerts/tesla_fleet.md
+++ b/alerts/tesla_fleet.md
@@ -10,6 +10,6 @@ On Febuary 1st 2025, Tesla is starting it's pay-per-use billing of the Tesla Fle
 
 Tesla has disabled this client ID, so all users of the Tesla Fleet integration need to upgrade to 2025.1 or later, and follow the [documentation](https://www.home-assistant.io/integrations/tesla_fleet/#configuration) configuration steps to setup a new developer application.
 
-If you are unable to setup your own developer application, Home Assistant has other paid integrations for working with Tesla:
+If you are unable to setup your own developer application, Home Assistant has other paid integrations that work with Tesla:
 - [Teslemetry](https://www.home-assistant.io/integrations/teslemetry)
 - [Tessie](https://www.home-assistant.io/integrations/tessie)

--- a/alerts/tesla_fleet.md
+++ b/alerts/tesla_fleet.md
@@ -1,0 +1,15 @@
+---
+title: Tesla Fleet built-in credential is being disabled
+created: 2025-01-30 12:00:00
+integrations:
+  - tesla_fleet
+homeassistant: "<2025.1"
+---
+
+On Febuary 1st 2025, Tesla is starting it's pay-per-use billing of the Tesla Fleet API, which impacts the client ID that was built into the Tesla Fleet integration before 2025.1.
+
+Tesla is going to remotely disable this client ID, so all users of the Tesla Fleet integration need to upgrade to 2025.1 or later, and follow the [documentation](https://www.home-assistant.io/integrations/tesla_fleet/#configuration) configuration steps to setup a new developer application.
+
+If you are unable to setup your own developer application, Home Assistant has other paid integrations for working with Tesla:
+- [Teslemetry](https://www.home-assistant.io/integrations/teslemetry)
+- [Tessie](https://www.home-assistant.io/integrations/tessie)

--- a/alerts/tesla_fleet.md
+++ b/alerts/tesla_fleet.md
@@ -8,7 +8,7 @@ homeassistant: "<2025.1"
 
 On Febuary 1st 2025, Tesla is starting it's pay-per-use billing of the Tesla Fleet API, which impacts the client ID that was built into the Tesla Fleet integration before 2025.1.
 
-Tesla has disable this client ID, so all users of the Tesla Fleet integration need to upgrade to 2025.1 or later, and follow the [documentation](https://www.home-assistant.io/integrations/tesla_fleet/#configuration) configuration steps to setup a new developer application.
+Tesla has disabled this client ID, so all users of the Tesla Fleet integration need to upgrade to 2025.1 or later, and follow the [documentation](https://www.home-assistant.io/integrations/tesla_fleet/#configuration) configuration steps to setup a new developer application.
 
 If you are unable to setup your own developer application, Home Assistant has other paid integrations for working with Tesla:
 - [Teslemetry](https://www.home-assistant.io/integrations/teslemetry)

--- a/alerts/tesla_fleet.md
+++ b/alerts/tesla_fleet.md
@@ -8,7 +8,7 @@ homeassistant: "<2025.1"
 
 On Febuary 1st 2025, Tesla is starting it's pay-per-use billing of the Tesla Fleet API, which impacts the client ID that was built into the Tesla Fleet integration before 2025.1.
 
-Tesla is going to remotely disable this client ID, so all users of the Tesla Fleet integration need to upgrade to 2025.1 or later, and follow the [documentation](https://www.home-assistant.io/integrations/tesla_fleet/#configuration) configuration steps to setup a new developer application.
+Tesla has disable this client ID, so all users of the Tesla Fleet integration need to upgrade to 2025.1 or later, and follow the [documentation](https://www.home-assistant.io/integrations/tesla_fleet/#configuration) configuration steps to setup a new developer application.
 
 If you are unable to setup your own developer application, Home Assistant has other paid integrations for working with Tesla:
 - [Teslemetry](https://www.home-assistant.io/integrations/teslemetry)


### PR DESCRIPTION
As discussed briefly on Discord, Tesla is going to start charging me personally for the use of every Home Assistant user with the previously built in Client ID. This was removed in 2025.1, but I know some people stayed on 2024.x so that they could keep using this credential.

I have raised a support request with Tesla to disable it before billing goes into effect on Febuary 1st.

I am more than happy for this alert to be reworded as much as required, and I know lots of people are struggling with the new configuration requirements, so I wanted to offer alternatives, which I also happen to be the Code Owner of.

Disclosure: I have a conflict of interest in that I personally own and operate Teslemetry.com