### PR TITLE
OAuth alert for Tesla Fleet

### DIFF
--- a/alerts/tesla_fleet.md
+++ b/alerts/tesla_fleet.md
@@ -6,8 +6,14 @@ integrations:
 homeassistant: "<2025.7.4"
 ---
 
-Tesla has announced that the original Tesla Fleet API OAuth endpoint is being deprecated on August 1st, 2025.
+Tesla has announced that the original Tesla Fleet API OAuth endpoint is being rate limited starting August 1st, 2025.
 
-Home Assistant has been updated to use the new OAuth endpoint in 2025.7.4, which means all previous versions of Home Assistant will fail to authentication with Tesla after August 1st, 2025.
+Home Assistant has been updated to use the new OAuth endpoint in 2025.7.4, however all previous versions of Home Assistant will be subject to authentication rate limits, which _may_ cause authentication issues after August 1st, 2025.
 
-Please update to 2025.7.4 or later to continue using the Tesla Fleet integration.
+> Fleet API Partner,
+>
+> Our logs show that your integration is still using https://auth.tesla.com/ for token exchange. As part of our ongoing improvements, we introduced a domain dedicated to Fleet API token exchange with increased rate limits and reliability: https://fleet-auth.prd.vn.cloud.tesla.com/. Please migrate to this domain in the next few weeks to avoid being rate limited.
+>
+> Action required - Update the domain used for calls to /token endpoints by August 1st, 2025.
+>
+> No other changes are required - This is a host-only update for token acquisition. Credentials, Fleet API domains, existing authorizations, endpoints, streaming configurations all remain unchanged.

--- a/alerts/tesla_fleet.md
+++ b/alerts/tesla_fleet.md
@@ -1,0 +1,13 @@
+---
+title: Tesla Fleet Authentication Endpoint
+created: 2024-07-23 00:00:00
+integrations:
+  - tesla_fleet
+homeassistant: "<2025.7.4"
+---
+
+Tesla has announced that the original Tesla Fleet API OAuth endpoint is being deprecated on August 1st, 2025.
+
+Home Assistant has been updated to use the new OAuth endpoint in 2025.7.4, which means all previous versions of Home Assistant will fail to authentication with Tesla after August 1st, 2025.
+
+Please update to 2025.7.4 or later to continue using the Tesla Fleet integration.


### PR DESCRIPTION
Tesla has just announced that the old OAuth endpoint is going to be rate limited from August 1st and needs to be replaced. This alert advises people they must update Home Assistant before August 1st to avoid any potential auth issues.

https://github.com/home-assistant/core/pull/149280

> Fleet API Partner,
>
> Our logs show that your integration is still using https://auth.tesla.com/ for token exchange. As part of our ongoing improvements, we introduced a domain dedicated to Fleet API token exchange with increased rate limits and reliability: https://fleet-auth.prd.vn.cloud.tesla.com/. Please migrate to this domain in the next few weeks to avoid being rate limited.
>
> Action required - Update the domain used for calls to /token endpoints by August 1st, 2025.
>
> No other changes are required - This is a host-only update for token acquisition. Credentials, Fleet API domains, existing authorizations, endpoints, streaming configurations all remain unchanged.