### PR TITLE
Add alert for Yale integration API changes requiring 2025.8.0+

### DIFF
--- a/alerts/yale.md
+++ b/alerts/yale.md
@@ -1,0 +1,9 @@
+---
+title: Yale integration will soon require Home Assistant 2025.8.0 or later
+created: 2025-08-05 00:00:00
+integrations:
+  - yale
+homeassistant: "<2025.8.0"
+---
+
+The Yale integration will stop working soon without Home Assistant 2025.8.0 or later. Please update your Home Assistant installation to version 2025.8.0 or later to ensure continued functionality of the Yale integration.


### PR DESCRIPTION
## Summary

This PR adds an alert to notify users that they need to update to Home Assistant 2025.8.0 or later to continue using the Yale integration.

## Background

Home Assistant 2025.8.0 includes a critical fix that significantly reduces API traffic to Yale's servers. Without this update, older versions of Home Assistant will be rate limited or blocked by Yale's API, causing the integration to stop working.

## Changes

- Added `alerts/yale.md` with a warning for users on versions below 2025.8.0
- Alert clearly indicates the integration "will stop working soon" to set proper expectations

## Impact

Users running Home Assistant versions older than 2025.8.0 will see this alert and be prompted to update before their Yale integration stops functioning due to API restrictions.