### PR TITLE
Add alert for August integration API changes requiring 2025.9.0+

### DIFF
--- a/alerts/august.md
+++ b/alerts/august.md
@@ -1,0 +1,9 @@
+---
+title: August integration will soon require Home Assistant 2025.9.0 or later
+created: 2025-09-05 00:00:00
+integrations:
+  - august
+homeassistant: "<2025.9.0"
+---
+
+The August integration will stop working soon without Home Assistant 2025.9.0 or later. Please update your Home Assistant installation to version 2025.9.0 or later to ensure continued functionality of the August integration.


### PR DESCRIPTION
## Purpose
Add an alert notifying Home Assistant users that they need to update to version 2025.9.0 or later for the August integration to continue working.

## Background
Similar to the Yale integration changes in #670, Home Assistant 2025.9.0 includes a critical fix that significantly reduces API traffic to August's servers. Yale has already disabled their old API endpoint, and August will be following suit. Without this update, the integration will completely stop working when August disables the old API path.

## Changes
- Added `alerts/august.md` with a warning for users on Home Assistant versions below 2025.9.0
- Alert clearly indicates the integration "will stop working soon" without the update

## Impact
- Users on Home Assistant versions before 2025.9.0 will be prompted to update
- Prevents potential integration failure due to API restrictions
- Ensures continued functionality of the August integration

## References
- Similar to #670 (Yale integration API changes)