### PR TITLE
Add alert for AccuWeather API change

### DIFF
--- a/alerts/accuweather.md
+++ b/alerts/accuweather.md
@@ -1,0 +1,13 @@
+---
+title: AccuWeather API keys have expired.
+created: 2025-09-09 12:00:00
+integrations:
+  - accuweather
+homeassistant: ">0.114"
+---
+
+On September 9, 2025, AccuWeather unveiled a new version of its API. The existing API keys have expired and the new API keys are not compatible with the integration. Furthermore, AccuWeather currently does not offer a free plan for access to its API; only paid plans are available. You can check details [here](https://developer.accuweather.com/pricing).
+
+
+You can follow the issue here.
+[Issue tracker](https://github.com/home-assistant/core/issues/149554)


### PR DESCRIPTION
Relates to https://github.com/home-assistant/core/issues/149554

All old API keys have expired, currently new keys are not compatible with the integration - a change to the backend library is required.