### PR TITLE
Change Home Assistant version for AccuWeather alert

### DIFF
--- a/alerts/accuweather.md
+++ b/alerts/accuweather.md
@@ -3,7 +3,7 @@ title: AccuWeather API keys have expired.
 created: 2025-09-09 12:00:00
 integrations:
   - accuweather
-homeassistant: ">0.114"
+homeassistant: "<2025.9.2"
 ---
 
 On September 9, 2025, AccuWeather unveiled a new version of its API. The existing API keys have expired and the new API keys are not compatible with the integration. Furthermore, AccuWeather currently does not offer a free plan for access to its API; only paid plans are available. You can check details [here](https://developer.accuweather.com/pricing).


### PR DESCRIPTION
Starting with HA 2025.9.2 the integration supports new API keys.